### PR TITLE
Most of the remaining pre-defined symbol ids for expressions.

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,7 +51,13 @@ def main():
     symbol_ids.add('(', id=0x41)
     symbol_ids.add(')', id=0x42)
     symbol_ids.add('||', id=0x43)
-    symbol_ids.add('&&', id=0x44)
+    symbol_ids.add('&&', id=0x44)    
+    
+    symbol_ids.add('|', id=0x45)
+    symbol_ids.add('&', id=0x46)
+    symbol_ids.add('^', id=0x47)
+    symbol_ids.add('<<', id=0x48)
+    symbol_ids.add('>>', id=0x49)
     
     symbol_ids.add('==', id=0x4a)
     symbol_ids.add('!=', id=0x4b)
@@ -60,6 +66,7 @@ def main():
     symbol_ids.add('>=', id=0x4e)
     symbol_ids.add('<=', id=0x4f)
     
+    symbol_ids.add('%', id=0x52)
     symbol_ids.add('+', id=0x53)
     symbol_ids.add('-', id=0x54)
     symbol_ids.add('*', id=0x55)


### PR DESCRIPTION
It seems like symbol ids and instruction ids don't overlap at all. If that's truly the case, the only symbols left are ids 0x50 and 0x51.

The ones added here are all of the bitwise operations, bit shifting, and the modulo operator.

All of these operators have been tested in a custom-made script so I'm fairly certain they're right